### PR TITLE
Fixed reg-exp in GetSiteIdentifiers function

### DIFF
--- a/src/EduHub.Data/EduHubContextBase.cs
+++ b/src/EduHub.Data/EduHubContextBase.cs
@@ -148,7 +148,7 @@ namespace EduHub.Data
             if (!Directory.Exists(EduHubDirectory))
                 throw new ArgumentException($"EduHub Directory [{EduHubDirectory}] does not exist");
 
-            var testSiteIdentifier = new Regex(@".*_(.+)(?<!_D).csv$", RegexOptions.IgnoreCase);
+            var testSiteIdentifier = new Regex(@".*?_(.+?)(_D)?.csv$", RegexOptions.IgnoreCase);
             var siteIdentifiers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var file in Directory.EnumerateFiles(EduHubDirectory, "*.csv"))


### PR DESCRIPTION
The current GetSiteIdentifiers function works wrong because it determines "D" as a site ID as well and always throws an error that there are multiple site IDs found and you must manually pass site ID as an argument.
